### PR TITLE
Remove tags and projects from front matter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,3 @@
----
-tags: []
-projects: []
----
 :spring_version: current
 :spring_boot_version: 1.5.8.RELEASE
 :Controller: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html


### PR DESCRIPTION
As of spring-io/sagan#760 and spring-io/sagan#784, Sagan:
* does not render tags nor understanding links anymore
* associates a guide to a list of projects using guide metadata
listed in the guide title itself like

`Guide title :: Guide subtitle :: spring-boot,spring-data-jpa`