### PR TITLE
Fix outdated Hystrix reference in circuit breaker guide

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -211,7 +211,7 @@ Run both the Bookstore service and the Reading service, and then open a browser 
 Spring in Action (Manning), Cloud Native Java (O'Reilly), Learning Spring Boot (Packt)
 ----
 
-Now shut down the Bookstore application. Our list source is gone, but thanks to Hystrix and Spring Cloud Netflix, we have a reliable abbreviated list to stand in the gap; you should see:
+Now shut down the Bookstore application. Our list source is gone, but thanks to Spring Cloud Circuit Breaker with Resilience4J, we have a reliable abbreviated list to stand in the gap; you should see:
 
 ----
 Cloud Native Java (O'Reilly)


### PR DESCRIPTION
This guide uses Spring Cloud Circuit Breaker with Resilience4J, but the summary section still referenced Hystrix and Spring Cloud Netflix. Updated the wording to match the implementation used in the guide.
